### PR TITLE
Replace conversation minimap with scroll progress slider

### DIFF
--- a/frontend/src/components/conversation/conversation-viewer.tsx
+++ b/frontend/src/components/conversation/conversation-viewer.tsx
@@ -212,13 +212,15 @@ export function ConversationViewer({
     }
   }, [initialIndex, visibleMessages, virtualizer]);
 
-  // Jump to position from progress bar click
+  // Jump to position from progress bar seek
   const handleProgressJump = useCallback(
     (ratio: number) => {
-      const idx = Math.floor(ratio * visibleMessages.length);
-      virtualizer.scrollToIndex(Math.max(0, Math.min(idx, visibleMessages.length - 1)), { align: "start" });
+      const el = parentRef.current;
+      if (!el) return;
+      const clamped = Math.max(0, Math.min(ratio, 1));
+      el.scrollTop = clamped * (el.scrollHeight - el.clientHeight);
     },
-    [visibleMessages.length, virtualizer]
+    []
   );
 
   // Navigate search matches

--- a/frontend/src/components/conversation/conversation-viewer.tsx
+++ b/frontend/src/components/conversation/conversation-viewer.tsx
@@ -10,7 +10,7 @@ import {
   deleteBookmark,
 } from "@/api/client";
 import { ConversationMessage } from "./conversation-message";
-import { ConversationMinimap } from "./conversation-minimap";
+import { ScrollProgress } from "./scroll-progress";
 import { BookmarkDialog } from "./bookmark-dialog";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -155,14 +155,18 @@ export function ConversationViewer({
     });
   }, [messages, toolsByMessage, roleFilter]);
 
-  // Tool count by message_index for minimap
-  const toolCountByIndex = useMemo(() => {
-    const map = new Map<number, number>();
-    for (const [idx, tools] of toolsByMessage) {
-      map.set(idx, tools.length);
-    }
-    return map;
-  }, [toolsByMessage]);
+  // Scroll progress tracking
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollHeight - el.clientHeight;
+      setScrollProgress(max > 0 ? el.scrollTop / max : 0);
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
 
   // Search matches
   const searchMatches = useMemo(() => {
@@ -197,11 +201,7 @@ export function ConversationViewer({
     overscan: 5,
   });
 
-  // Visible range for minimap
   const virtualItems = virtualizer.getVirtualItems();
-  const visibleRange: [number, number] = virtualItems.length > 0
-    ? [virtualItems[0].index, virtualItems[virtualItems.length - 1].index]
-    : [0, 0];
 
   // Scroll to initial message_index (convert from message_index to visible array position)
   useEffect(() => {
@@ -212,12 +212,13 @@ export function ConversationViewer({
     }
   }, [initialIndex, visibleMessages, virtualizer]);
 
-  // Jump to message from minimap
-  const handleMinimapJump = useCallback(
-    (index: number) => {
-      virtualizer.scrollToIndex(index, { align: "start" });
+  // Jump to position from progress bar click
+  const handleProgressJump = useCallback(
+    (ratio: number) => {
+      const idx = Math.floor(ratio * visibleMessages.length);
+      virtualizer.scrollToIndex(Math.max(0, Math.min(idx, visibleMessages.length - 1)), { align: "start" });
     },
-    [virtualizer]
+    [visibleMessages.length, virtualizer]
   );
 
   // Navigate search matches
@@ -255,16 +256,7 @@ export function ConversationViewer({
     : 0;
 
   return (
-    <div className="flex h-[calc(100vh-14rem)] gap-2">
-      {/* Minimap */}
-      <ConversationMinimap
-        messages={visibleMessages}
-        toolCountByIndex={toolCountByIndex}
-        visibleRange={visibleRange}
-        onJump={handleMinimapJump}
-        className="hidden w-10 shrink-0 lg:block"
-      />
-
+    <div className="flex h-[calc(100vh-14rem)]">
       {/* Main conversation area */}
       <div className="flex flex-1 flex-col overflow-hidden rounded-lg border">
         {/* Search bar */}
@@ -376,6 +368,13 @@ export function ConversationViewer({
             })}
           </div>
         </div>
+
+        {/* Scroll progress */}
+        <ScrollProgress
+          progress={scrollProgress}
+          messageCount={visibleMessages.length}
+          onSeek={handleProgressJump}
+        />
 
         {/* Token usage bar */}
         {tokens && totalTokens > 0 && (

--- a/frontend/src/components/conversation/scroll-progress.tsx
+++ b/frontend/src/components/conversation/scroll-progress.tsx
@@ -33,6 +33,8 @@ export function ScrollProgress({
       <div className="flex items-center gap-2">
         <input
           type="range"
+          aria-label="Conversation scroll position"
+          aria-valuetext={`${percent}% through conversation`}
           min={0}
           max={100}
           value={percent}

--- a/frontend/src/components/conversation/scroll-progress.tsx
+++ b/frontend/src/components/conversation/scroll-progress.tsx
@@ -1,0 +1,50 @@
+import { useCallback } from "react";
+import { cn } from "@/lib/utils";
+
+interface ScrollProgressProps {
+  /** 0–1 ratio of scroll position. */
+  progress: number;
+  /** Total message count for label. */
+  messageCount: number;
+  /** Called with a 0–1 ratio when the user seeks. */
+  onSeek: (ratio: number) => void;
+  className?: string;
+}
+
+export function ScrollProgress({
+  progress,
+  messageCount,
+  onSeek,
+  className,
+}: ScrollProgressProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onSeek(Number(e.target.value) / 100);
+    },
+    [onSeek]
+  );
+
+  if (messageCount === 0) return null;
+
+  const percent = Math.round(progress * 100);
+
+  return (
+    <div className={cn("border-t px-4 py-1.5", className)}>
+      <div className="flex items-center gap-2">
+        <input
+          type="range"
+          min={0}
+          max={100}
+          value={percent}
+          onChange={handleChange}
+          className="h-1.5 flex-1 cursor-pointer appearance-none rounded-full bg-muted accent-primary
+            [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary
+            [&::-moz-range-thumb]:h-3 [&::-moz-range-thumb]:w-3 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-primary"
+        />
+        <span className="text-[10px] tabular-nums text-muted-foreground w-7 text-right">
+          {percent}%
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Removes the vertical minimap sidebar from the conversation viewer
- Adds a horizontal range slider at the bottom for scroll position tracking and seeking
- Slider is more accurate, takes less space, and supports drag interaction

Closes #66

## Test plan
- [x] Verified scroll progress updates as conversation is scrolled
- [x] Verified slider click/drag seeks to correct position
- [x] Verified build passes with no type errors
- [x] Visually verified via Playwright screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation navigation replaced the minimap with a scroll-progress control: shows current scroll percentage, message count, and an interactive seek slider so users can jump to any point in a conversation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->