### PR TITLE
Fix stale latest_session_id on active session cards

### DIFF
--- a/claude_code_analytics/api/routers/active.py
+++ b/claude_code_analytics/api/routers/active.py
@@ -29,31 +29,8 @@ async def get_active_sessions(
     """
     active = get_active_sessions_cached()
 
-    # Fetch summaries once — used for both latest_session_id lookup and recent section
+    # Fetch summaries once — used for the recent section
     summaries = db.get_session_summaries()
-
-    # Build lookup: project_name (full path) -> latest *user* session_id
-    # Skip subagent sessions (prefixed with "agent-") so users land on a top-level session
-    latest_by_project: dict[str, str] = {}
-    for s in summaries:
-        if not s.project_name or not s.session_id:
-            continue
-        if s.session_id.startswith("agent-"):
-            continue
-        if not s.start_time:
-            continue
-        existing = latest_by_project.get(s.project_name)
-        if existing is None:
-            latest_by_project[s.project_name] = s.session_id
-        else:
-            # Compare start_time to keep the latest
-            existing_summary = next((x for x in summaries if x.session_id == existing), None)
-            if (
-                existing_summary
-                and existing_summary.start_time
-                and s.start_time > existing_summary.start_time
-            ):
-                latest_by_project[s.project_name] = s.session_id
 
     recent = []
     if include_recent:
@@ -110,7 +87,7 @@ async def get_active_sessions(
                 "duration_minutes": s.duration_minutes,
                 "status": s.status,
                 "recent_messages": s.recent_messages,
-                "latest_session_id": latest_by_project.get(s.project_dir),
+                "latest_session_id": s.latest_session_id,
             }
             for s in active
         ],

--- a/claude_code_analytics/api/services/process_scanner.py
+++ b/claude_code_analytics/api/services/process_scanner.py
@@ -36,6 +36,7 @@ class ActiveSession:
     status: str = "running"
     recent_messages: list[str] = field(default_factory=list)
     duration_minutes: int = 0
+    latest_session_id: str | None = None
 
 
 @dataclass
@@ -220,9 +221,13 @@ def scan_active_sessions() -> list[ActiveSession]:
         project_name = Path(cwd).name
         started_at = proc["started_at"]
         duration = now - started_at
-        # Extract recent user messages from JSONL
+        # Extract recent user messages from JSONL.
+        # The JSONL stem is also the session_id — use it directly as the click target
+        # so the active card is always consistent with what the user is looking at,
+        # rather than relying on a separate DB query that may pick a stale session.
         jsonl_path = _find_latest_jsonl(cwd)
         recent_messages = _extract_recent_messages(jsonl_path) if jsonl_path else []
+        latest_session_id = jsonl_path.stem if jsonl_path else None
 
         sessions.append(
             ActiveSession(
@@ -233,6 +238,7 @@ def scan_active_sessions() -> list[ActiveSession]:
                 started_at=started_at.isoformat(),
                 recent_messages=recent_messages,
                 duration_minutes=int(duration.total_seconds() / 60),
+                latest_session_id=latest_session_id,
             )
         )
 


### PR DESCRIPTION
## Summary
- Active session cards were linking to a stale session_id when a long-running session was still actively writing to its JSONL file
- Root cause: router selected "latest" by `start_time`, which picked a newer-started but inactive session over a long-running but still-active one
- Fix: use the JSONL file with the most recent mtime (already found by the process scanner for `recent_messages`) as the authoritative `session_id` for the click target

Closes #71

## Test plan
- [x] Verified locally: `instantdemo` active session now correctly links to `e235c649-...` (the actively-running session) instead of `7b5d9159-...` (a stale May 6 session)
- [x] All 213 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized the `GET /active-sessions` endpoint to improve session tracking efficiency and data retrieval.
  * Enhanced active session information to directly capture the latest session identifier from session data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sujankapadia/claude-code-analytics/pull/72)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->