### PR TITLE
Support date range queries on daily analytics endpoint

### DIFF
--- a/claude_code_analytics/api/routers/analytics.py
+++ b/claude_code_analytics/api/routers/analytics.py
@@ -9,9 +9,18 @@ router = APIRouter(prefix="/analytics", tags=["analytics"])
 
 
 @router.get("/daily")
-def get_daily_stats(days: int = 30, db: DatabaseService = Depends(get_db_service)):
-    """Get daily aggregated statistics."""
-    return db.get_daily_statistics(days=days)
+def get_daily_stats(
+    days: int = 30,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    db: DatabaseService = Depends(get_db_service),
+):
+    """Get daily aggregated statistics.
+
+    If start_date and/or end_date (YYYY-MM-DD) are provided, they take precedence
+    over `days`. end_date is inclusive.
+    """
+    return db.get_daily_statistics(days=days, start_date=start_date, end_date=end_date)
 
 
 @router.get("/tools")

--- a/claude_code_analytics/services/database_service.py
+++ b/claude_code_analytics/services/database_service.py
@@ -1705,35 +1705,73 @@ class DatabaseService:
             "avg_active_time_per_session": avg_active,
         }
 
-    def get_daily_statistics(self, days: int = 30) -> list[dict[str, Any]]:
+    def get_daily_statistics(
+        self,
+        days: int = 30,
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> list[dict[str, Any]]:
         """
         Get daily aggregated statistics.
 
+        If start_date and/or end_date are provided, they take precedence over `days`.
+        Dates must be ISO format (YYYY-MM-DD). end_date is inclusive.
+
         Args:
-            days: Number of days to include
+            days: Number of days to include (used when no date range is given)
+            start_date: Inclusive lower bound (YYYY-MM-DD)
+            end_date: Inclusive upper bound (YYYY-MM-DD)
 
         Returns:
             Daily statistics
         """
         conn = self._get_connection()
         cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT
-                DATE(timestamp) as date,
-                COUNT(DISTINCT session_id) as sessions,
-                COUNT(*) as messages,
-                SUM(CASE WHEN role = 'user' THEN 1 ELSE 0 END) as user_messages,
-                SUM(CASE WHEN role = 'assistant' THEN 1 ELSE 0 END) as assistant_messages,
-                SUM(COALESCE(input_tokens, 0)) as input_tokens,
-                SUM(COALESCE(output_tokens, 0)) as output_tokens
-            FROM messages
-            WHERE timestamp >= datetime('now', '-' || ? || ' days')
-            GROUP BY DATE(timestamp)
-            ORDER BY date DESC
-            """,
-            (days,),
-        )
+        if start_date or end_date:
+            clauses = []
+            params: list[Any] = []
+            if start_date:
+                clauses.append("DATE(timestamp) >= ?")
+                params.append(start_date)
+            if end_date:
+                clauses.append("DATE(timestamp) <= ?")
+                params.append(end_date)
+            where = " AND ".join(clauses)
+            cursor.execute(
+                f"""
+                SELECT
+                    DATE(timestamp) as date,
+                    COUNT(DISTINCT session_id) as sessions,
+                    COUNT(*) as messages,
+                    SUM(CASE WHEN role = 'user' THEN 1 ELSE 0 END) as user_messages,
+                    SUM(CASE WHEN role = 'assistant' THEN 1 ELSE 0 END) as assistant_messages,
+                    SUM(COALESCE(input_tokens, 0)) as input_tokens,
+                    SUM(COALESCE(output_tokens, 0)) as output_tokens
+                FROM messages
+                WHERE {where}
+                GROUP BY DATE(timestamp)
+                ORDER BY date DESC
+                """,
+                params,
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT
+                    DATE(timestamp) as date,
+                    COUNT(DISTINCT session_id) as sessions,
+                    COUNT(*) as messages,
+                    SUM(CASE WHEN role = 'user' THEN 1 ELSE 0 END) as user_messages,
+                    SUM(CASE WHEN role = 'assistant' THEN 1 ELSE 0 END) as assistant_messages,
+                    SUM(COALESCE(input_tokens, 0)) as input_tokens,
+                    SUM(COALESCE(output_tokens, 0)) as output_tokens
+                FROM messages
+                WHERE timestamp >= datetime('now', '-' || ? || ' days')
+                GROUP BY DATE(timestamp)
+                ORDER BY date DESC
+                """,
+                (days,),
+            )
         rows = cursor.fetchall()
         conn.close()
         return [dict(row) for row in rows]

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -98,8 +98,11 @@ export const fetchSimilarSessions = (params: {
 
 // -- Analytics --
 
-export const fetchDailyStats = (days?: number) =>
-  get<DailyStats[]>("/analytics/daily", { days });
+export const fetchDailyStats = (params?: {
+  days?: number;
+  start_date?: string;
+  end_date?: string;
+}) => get<DailyStats[]>("/analytics/daily", params);
 
 export const fetchToolStats = () => get<ToolUsageSummary[]>("/analytics/tools");
 

--- a/frontend/src/pages/analytics.tsx
+++ b/frontend/src/pages/analytics.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import {
@@ -18,15 +19,54 @@ import { ActiveTimeBarChart } from "@/components/charts/active-time-bar-chart";
 import { formatNumber, formatDuration, shortProjectName } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
+type DateRange = "30d" | "90d" | "month" | "year" | "all";
+
+const RANGE_LABELS: Record<DateRange, string> = {
+  "30d": "Last 30 days",
+  "90d": "Last 90 days",
+  month: "This month",
+  year: "This year",
+  all: "All time",
+};
+
+function rangeToParams(range: DateRange): {
+  days?: number;
+  start_date?: string;
+  end_date?: string;
+} {
+  const now = new Date();
+  const iso = (d: Date) => d.toISOString().slice(0, 10);
+  switch (range) {
+    case "30d":
+      return { days: 30 };
+    case "90d":
+      return { days: 90 };
+    case "month":
+      return {
+        start_date: iso(new Date(now.getFullYear(), now.getMonth(), 1)),
+        end_date: iso(now),
+      };
+    case "year":
+      return {
+        start_date: `${now.getFullYear()}-01-01`,
+        end_date: iso(now),
+      };
+    case "all":
+      return { days: 100000 };
+  }
+}
+
 export default function AnalyticsPage() {
+  const [range, setRange] = useState<DateRange>("30d");
+
   const { data: tools } = useQuery({
     queryKey: ["analytics", "tools"],
     queryFn: fetchToolStats,
   });
 
   const { data: daily } = useQuery({
-    queryKey: ["analytics", "daily", 30],
-    queryFn: () => fetchDailyStats(30),
+    queryKey: ["analytics", "daily", range],
+    queryFn: () => fetchDailyStats(rangeToParams(range)),
   });
 
   const { data: mcp } = useQuery({
@@ -65,7 +105,25 @@ export default function AnalyticsPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-bold">Analytics</h1>
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <h1 className="text-2xl font-bold">Analytics</h1>
+        <div className="flex gap-1 rounded-lg border bg-card p-1">
+          {(Object.keys(RANGE_LABELS) as DateRange[]).map((r) => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={cn(
+                "rounded px-2.5 py-1 text-xs font-medium transition-colors",
+                range === r
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {RANGE_LABELS[r]}
+            </button>
+          ))}
+        </div>
+      </div>
 
       {/* Top row: charts */}
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -29,7 +29,7 @@ export default function DashboardPage() {
 
   const { data: dailyStats } = useQuery({
     queryKey: ["analytics", "daily"],
-    queryFn: () => fetchDailyStats(30),
+    queryFn: () => fetchDailyStats({ days: 30 }),
   });
 
   const { data: activity } = useQuery({


### PR DESCRIPTION
## Summary
- `/analytics/daily` only accepted a relative `days` parameter, silently ignoring `start_date`/`end_date` query params
- This made it impossible to view specific calendar ranges like "this year" without passing a large `days` value
- Adds optional `start_date`/`end_date` (YYYY-MM-DD) params; date range takes precedence over `days` when provided
- Frontend: adds a date range selector to the analytics page (Last 30 days, Last 90 days, This month, This year, All time)

Closes #69

## Test plan
- [x] Verified locally: `?start_date=2026-01-01&end_date=2026-12-31` now returns full-year data (129 days, 2.3M input + 16.9M output tokens)
- [x] All 213 unit tests pass
- [x] Frontend type-checks and builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)